### PR TITLE
Improve Swiper usage

### DIFF
--- a/components/PaginationAdvertise.vue
+++ b/components/PaginationAdvertise.vue
@@ -2,54 +2,33 @@
 import { Swiper, SwiperSlide } from "swiper/vue";
 import { Pagination } from "swiper/modules";
 
+const slides = Array.from({ length: 4 });
+
 import "swiper/css";
 import "swiper/css/pagination";
 </script>
 <template>
-  <swiper
-    ref="mySwiper"
-    :slides-per-view="1"
-    :pagination="{ clickable: true }"
-    :modules="[SwiperPagination]"
-    class="PaginationAdvertise"
-  >
-    <swiper-slide>
-      <div class="LittleAdvertise flex justify-center">
-        <img src="../assets/images/LittleAdvertise.svg" alt="" class="photo" />
-        <img
-          src="../assets/icon/play.svg"
-          alt=""
-          class="LittleAdvertise__icon"
-        /></div
-    ></swiper-slide>
-    <swiper-slide>
-      <div class="LittleAdvertise flex justify-center">
-        <img src="../assets/images/LittleAdvertise.svg" alt="" class="photo" />
-        <img
-          src="../assets/icon/play.svg"
-          alt=""
-          class="LittleAdvertise__icon"
-        /></div
-    ></swiper-slide>
-    <swiper-slide>
-      <div class="LittleAdvertise flex justify-center">
-        <img src="../assets/images/LittleAdvertise.svg" alt="" class="photo" />
-        <img
-          src="../assets/icon/play.svg"
-          alt=""
-          class="LittleAdvertise__icon"
-        /></div
-    ></swiper-slide>
-    <swiper-slide>
-      <div class="LittleAdvertise flex justify-center">
-        <img src="../assets/images/LittleAdvertise.svg" alt="" class="photo" />
-        <img
-          src="../assets/icon/play.svg"
-          alt=""
-          class="LittleAdvertise__icon"
-        /></div
-    ></swiper-slide>
-  </swiper>
+  <client-only>
+    <swiper
+      ref="mySwiper"
+      :slides-per-view="1"
+      :pagination="{ clickable: true }"
+      :modules="[Pagination]"
+      class="PaginationAdvertise"
+    >
+      <swiper-slide v-for="(_, index) in slides" :key="index">
+        <div class="LittleAdvertise flex justify-center">
+          <img src="~/assets/images/LittleAdvertise.svg" alt="" class="photo" loading="lazy" />
+          <img
+            src="~/assets/icon/play.svg"
+            alt=""
+            class="LittleAdvertise__icon"
+            loading="lazy"
+          />
+        </div>
+      </swiper-slide>
+    </swiper>
+  </client-only>
 </template>
 
 <style lang="scss" scoped>

--- a/pages/issue/components/IssueInfo.vue
+++ b/pages/issue/components/IssueInfo.vue
@@ -111,7 +111,7 @@ watch(width, (newWidth) => {
           ref="mySwiper"
           :slides-per-view="1"
           :pagination="{ clickable: true }"
-          :modules="[SwiperPagination]"
+          :modules="[Pagination]"
           :class="'pic__swiper '"
         >
           <SwiperSlide><img :src="imgSrc" alt="" /></SwiperSlide>


### PR DESCRIPTION
## Summary
- simplify PaginationAdvertise.vue by looping slide content
- wrap swiper in client-only and fix module configuration
- correct pagination module usage in IssueInfo.vue

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: nuxt not found)*